### PR TITLE
chore: add labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,17 @@
+name: Add Labels
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Awaiting Triage Label
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "add-labels"
+          token: ${{ secrets.LABELS_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "meta:awaiting-triage"


### PR DESCRIPTION
Added workflow to automatically add `meta:awaiting-triage` label to new Issues